### PR TITLE
Fix xdg-install icon installation

### DIFF
--- a/xdg-install.sh
+++ b/xdg-install.sh
@@ -9,7 +9,7 @@ echo "Installing data files to: ${XDG_DATA_HOME:=$HOME/.local/share}"
 #export XDG_UTILS_DEBUG_LEVEL=1  #DEBUG
 
 for s in 48 64 128; do
-    xdg-icon-resource install --noupdate --size $s --context apps "icons/hicolor/apps/${size}x${size}/jupyter-nbmanager.png" jupyter-nbmanager
+    xdg-icon-resource install --noupdate --size $s --context apps "icons/hicolor/${s}x${s}/apps/jupyter-nbmanager.png" jupyter-nbmanager
 done
 xdg-icon-resource forceupdate
 


### PR DESCRIPTION
The xdg-install.sh script is confused about the name of a variable. This fixes that.

PS: Thanks for this program, I find it very convenient.