### PR TITLE
Use a standard icon for "Link" button

### DIFF
--- a/nbmanager/gui.py
+++ b/nbmanager/gui.py
@@ -17,7 +17,7 @@ class Icon(Enum):
     NbManager = 'jupyter-nbmanager'
     Server = 'go-home'
     Session = 'application-x-ipynb+json'
-    Link = 'link'
+    Link = 'go-jump'
     Shutdown = 'process-stop'
 
     @property


### PR DESCRIPTION
The icon named "link" is not a standard name from the freedesktop.org
Icon Naming Specification. Hence it may not be available on the user's
system, giving an unappealing blank button in the interface.

The icon "go-jump" is the standard icon for a "jump to action", which is
appropriate to the function of the button.